### PR TITLE
mmm... tasty motion_require kool-aid

### DIFF
--- a/lib/turnkey.rb
+++ b/lib/turnkey.rb
@@ -2,8 +2,6 @@ unless defined?(Motion::Project::Config)
   raise "This file must be required within a RubyMotion project Rakefile."
 end
 
-Motion::Project::App.setup do |app|
-  Dir.glob(File.join(File.dirname(__FILE__), 'turnkey/*.rb')).each do |file|
-    app.files.unshift(file)
-  end
-end
+require "motion-require"
+
+Motion::Require.all(Dir.glob(File.expand_path('../turnkey/**/*.rb', __FILE__)))

--- a/lib/turnkey/cache.rb
+++ b/lib/turnkey/cache.rb
@@ -1,3 +1,4 @@
+motion_require "sanitizers"
 module Turnkey
 
   class Cache

--- a/lib/turnkey/core.rb
+++ b/lib/turnkey/core.rb
@@ -1,3 +1,4 @@
+motion_require "proxy"
 module Turnkey
 
   def archive(instance, key)

--- a/lib/turnkey/proxy.rb
+++ b/lib/turnkey/proxy.rb
@@ -1,3 +1,4 @@
+motion_require "sanitizers"
 module Turnkey
 
   module Proxy

--- a/lib/turnkey/utility.rb
+++ b/lib/turnkey/utility.rb
@@ -1,3 +1,5 @@
+
+motion_require "sanitizers"
 module Turnkey
 
   class Utility

--- a/turnkey.gemspec
+++ b/turnkey.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]
-
+  s.add_runtime_dependency("motion-require", ">= 0.0.6")
 end


### PR DESCRIPTION
Uses motion_require to be compatible with newer ProMotion, motion-resource, and formation.
