### PR TITLE
Protect against internal instance variables without accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,18 @@ gem 'turnkey'
 To save a custom object to defaults, just pass the object, along with the key you'll use to retrieve it, to Turnkey's `archive` method:
 
 ```ruby
+class Song
+  attr_accessor :title, :artist
+end
+
 song = Song.new.tap{|s| s.title = "In Bloom"; s.artist = "Nirvana"}
 => #<Song:0x82b4ef0 @title="In Bloom" @artist="Nirvana">
 Turnkey.archive(song, "Nirvana Song")
 => true
 ```
 To retrieve it, call `unarchive`
+
+Note the system uses accessor methods to get and set the values when storing and recovering so be sure to use attr_accessors for the variable states you want to preserve. Internal instance variables without this are ignored.
 
 ```ruby
 Turnkey.unarchive("Nirvana Song")

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-$:.unshift("/Library/RubyMotion2.7/lib")
+$:.unshift("/Library/RubyMotion/lib")
 require 'motion/project/template/ios'
 
 $:.unshift("./lib/")

--- a/lib/turnkey/cache.rb
+++ b/lib/turnkey/cache.rb
@@ -30,9 +30,11 @@ module Turnkey
 
     def self.update_references(instance)
       instance.instance_variables.each do |prop|
-        value = instance.send(reader_sig_for(prop))
-        next if @@objs.include?(value.object_id)
-        update(value)
+        if instance.respond_to?(reader_sig_for(prop))
+          value = instance.send(reader_sig_for(prop))
+          next if @@objs.include?(value.object_id)
+          update(value)
+        end
       end
     end
 

--- a/lib/turnkey/proxy.rb
+++ b/lib/turnkey/proxy.rb
@@ -3,15 +3,13 @@ module Turnkey
   module Proxy
     include Turnkey::Sanitizers
 
-    #def self.included(base)
-    #  base.extend(ClassMethods)
-    #end
-
     def encodeWithCoder(encoder)
       #self.class.tk_vars = instance_variables
       instance_variables.each do |prop|
-        reader_sig = reader_sig_for(prop)
-        encoder.encodeObject(self.send(reader_sig), forKey: reader_sig)
+        if self.respond_to?(reader_sig_for(prop))
+          reader_sig = reader_sig_for(prop)
+          encoder.encodeObject(self.send(reader_sig), forKey: reader_sig)
+        end
       end
     end
 
@@ -20,25 +18,11 @@ module Turnkey
         property_list = Cache.attributesForClass(self.class)
         property_list.each do |prop|
           value = decoder.decodeObjectForKey(reader_sig_for(prop))
-          self.send(writer_sig_for(prop), value) if value
+          if self.respond_to?(writer_sig_for(prop)) && value
+            self.send(writer_sig_for(prop), value)
+          end
         end
       end
     end
-
-    #module ClassMethods
-    #
-    #  def tk_vars=(vars)
-    #    instance_eval do
-    #      @@vars ||= []
-    #      @@vars = @@vars | vars
-    #    end
-    #  end
-    #
-    #  def tk_vars
-    #    instance_eval do
-    #      @@vars
-    #    end
-    #  end
-    #end
   end
 end

--- a/lib/turnkey/utility.rb
+++ b/lib/turnkey/utility.rb
@@ -3,28 +3,16 @@ module Turnkey
   class Utility
     extend Sanitizers
 
-    #def self.defineProtocols(instance)
-    #  return if instance.respondsToSelector("encodeWithCoder:") && instance.respondsToSelector("initWithCoder:")
-    #  instance.class.class_eval {
-    #    include Turnkey::Proxy
-    #  }
-    #end
-    #
-    #def self.extend_protocols_to_object_references(instance)
-    #  instance.instance_variables.each do |prop|
-    #    value = instance.send(reader_sig_for(prop))
-    #    defineProtocols(value)
-    #  end
-    #end
-
     def self.defineProtocols(instance)
       return if alreadyDefined?(instance)
 
       includeCoderProtocols(instance)
 
       instance.instance_variables.each do |prop|
-        ref = instance.send(reader_sig_for(prop))
-        defineProtocols(ref)
+        if instance.respond_to?(reader_sig_for(prop))
+          ref = instance.send(reader_sig_for(prop))
+          defineProtocols(ref)
+        end
       end
     end
 

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -5,9 +5,11 @@ describe "Core" do
     class OtherObject;attr_accessor :name;end
     class ToBeArchived2;attr_accessor :name, :obj_ref;end
     class OtherObject2;attr_accessor :name;end
+    class Adaptive; attr_accessor :name; def doSomething; @something = true; end; end
     @object_ref = OtherObject.new.tap{|o| o.name = "Referenced Object"}
     @object_ref2 = OtherObject2.new.tap{|o| o.name = "Referenced Object"}
     @to_be_archived = ToBeArchived.new.tap{|tba| tba.name = "Archived";tba.obj_ref = @object_ref}
+    @adaptive = Adaptive.new.tap{|tba| tba.name = "Archived"; tba.doSomething }
   end
 
   describe "#archive" do
@@ -42,6 +44,13 @@ describe "Core" do
       unarched.name.should == "Archived"
       unarched.obj_ref.name.should == "Referenced Object"
       unarched.class.should == ToBeArchived
+    end
+
+    it "should unarchive object when passed identifier key and handle instance variables that have no accessor methods" do
+      Turnkey.archive(@adaptive, "TBA1")
+      unarched = Turnkey.unarchive("TBA1")
+      unarched.name.should == "Archived"
+      unarched.class.should == Adaptive
     end
   end
 end


### PR DESCRIPTION
Had an object that had an instance variable that came in at runtime via another gem. No getters / setters as it was not one of the values I cared about preserving. However the system would explode trying to fetch and restore the state of this variable. 

Changes will ensure the getter / setter methods exist before we try to call them. It does let variable state drop away though so have made a slight change to the readme to express this. I feel it's valid that you ensure there are accessors for the variable states you want to preserve. 

Longer term maybe look at instance variable get / set directly if it's worth pursuing full variable state preservation.
